### PR TITLE
build-test-push  github action

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -16,7 +16,7 @@ on:
         default: true
 
 jobs:
-  build:
+  build-test-push:
     runs-on: ubuntu-latest
     steps:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This should place you in `/wd` inside the container, where you can now run `matf
 
 The easiest way to build and deploy the image is through the [build-test-push](https://github.com/hpcflow/matflow-damask-image/actions/workflows/build-test-push.yml) action, which can be manually triggered.
 
+The image can be built and tested without pushing to ghcr.io by setting both inputs to false.
+
 ### Building locally
 
 Because matflow is installed using the single liner, with no reference to the version, it installs the latest version, but docker does not detect the version change, so new images need to be built with the `--no-cache` option:


### PR DESCRIPTION
Adds github action to build and deploy container image.

The workflow is manually triggered, and can be set to push with versioned tag, "latest" tag, or not push at all, to test the build only.